### PR TITLE
I've added a comparison of DB2 upgrade methods and scripts for two va…

### DIFF
--- a/db2_update/DB2_Upgrade_11.5_to_12.1.md
+++ b/db2_update/DB2_Upgrade_11.5_to_12.1.md
@@ -1,0 +1,236 @@
+# Comprehensive Guide: Upgrading IBM DB2 from Version 11.5 to Version 12.1
+
+**Version:** 1.0
+**Date:** 2024-06-18
+
+## 1. Introduction
+
+This guide provides a comprehensive overview and step-by-step considerations for upgrading an IBM DB2 environment from version 11.5 to version 12.1. A major version upgrade is a significant undertaking and requires careful planning, execution, and verification.
+
+**Disclaimer:** This guide is for informational purposes. Always refer to the official IBM DB2 Knowledge Center for your specific DB2 edition, FixPak level, and operating system for the most accurate and detailed instructions. Perform thorough testing in a non-production environment before attempting an upgrade in production.
+
+### Key Stages of Upgrade:
+1.  **Pre-Upgrade Tasks:** Preparing your current environment and databases.
+2.  **Installing DB2 Version 12.1 Software:** Setting up the new DB2 binaries.
+3.  **Upgrading DB2 Instances:** Migrating your existing instances to the new version.
+4.  **Upgrading Databases:** Migrating the actual databases to the new version.
+5.  **Post-Upgrade Tasks:** Verification, optimization, and final steps.
+
+---
+
+## 2. Phase 1: Pre-Upgrade Tasks
+
+Thorough preparation is crucial for a smooth upgrade.
+
+### 2.1. System Requirements for DB2 12.1
+*   **Operating System:** Verify that your OS version is supported by DB2 12.1. Refer to IBM's system requirements documentation.
+*   **Memory & Disk Space:** Ensure sufficient free memory and disk space for the DB2 12.1 installation, instance upgrade, and database upgrade (which can temporarily require more space).
+*   **Software Prerequisites:** Check for any required libraries, compilers, or OS patches for DB2 12.1.
+
+### 2.2. Full System Backup
+*   **Database Backups:** Perform full, offline (if possible) backups of ALL databases managed by the DB2 11.5 instance(s) you intend to upgrade.
+    *   You can use the `backup_db2.sh` script provided in the `scripts/` directory as a template. Ensure it's configured for your 11.5 environment.
+    *   Example: `su - db2inst1 -c "./scripts/backup_db2.sh"`
+    *   Verify backup completion and integrity.
+*   **Operating System & Application Backups:** Consider full system backups or backups of critical application components.
+
+### 2.3. Run `db2ckupgrade` Utility
+The `db2ckupgrade` command is essential. It checks if your databases are ready for an upgrade to the new version.
+*   **Obtain `db2ckupgrade`:** This utility is included with the DB2 Version 12.1 installation media. You do not need to install v12.1 yet; you can typically extract it from the installation image.
+*   **Execution:**
+    ```bash
+    # As instance owner of the 11.5 instance
+    su - <your_11.5_instance_owner>
+    # Path to db2ckupgrade from v12.1 media
+    /path_to_v12.1_media/server/db2ckupgrade <database_name> -l /tmp/db2ckupgrade_<database_name>.log -u <admin_user> -p <password>
+    ```
+*   **Review Logs:** Carefully examine the log file (e.g., `/tmp/db2ckupgrade_<database_name>.log`) for any errors or warnings.
+*   **Resolve Issues:** Address ALL issues reported by `db2ckupgrade` before proceeding. Common issues might include outdated table definitions, invalid objects, or features that need manual migration.
+
+### 2.4. Save DB2 Configuration
+Capture the current configuration of your DB2 environment.
+*   **Database Manager (DBM) Configuration:**
+    ```bash
+    su - <your_11.5_instance_owner> -c "db2 GET DBM CFG > /path_to_config_backup/dbm_cfg_11.5.txt"
+    ```
+*   **Database Configuration (for each database):**
+    ```bash
+    su - <your_11.5_instance_owner> -c "db2 CONNECT TO <database_name>; db2 GET DB CFG FOR <database_name> SHOW DETAIL > /path_to_config_backup/db_cfg_<database_name>_11.5.txt; db2 CONNECT RESET"
+    ```
+*   **`db2look` Output (for each database):** This utility generates DDL and statistics.
+    ```bash
+    su - <your_11.5_instance_owner> -c "db2look -d <database_name> -e -l -x -o /path_to_config_backup/db2look_<database_name>_11.5.sql"
+    ```
+*   **Registry Variables:**
+    ```bash
+    su - <your_11.5_instance_owner> -c "db2set -all > /path_to_config_backup/db2set_11.5.txt"
+    ```
+*   **Instance and System Information:** Note down OS version, DB2 FixPak level, disk layout, etc.
+
+### 2.5. Check for DPF (Database Partitioning Feature)
+*   If your DB2 11.5 environment uses DPF, the upgrade process is more complex and requires specific DPF upgrade procedures. This guide primarily focuses on non-DPF environments. Consult IBM documentation if you use DPF.
+
+### 2.6. Final Checks
+*   Ensure all applications are disconnected or quiesced.
+*   No outstanding transactions or utilities running on the databases.
+*   Sufficient downtime window approved for the upgrade.
+
+---
+
+## 3. Phase 2: Installing DB2 Version 12.1 Software
+
+### 3.1. Obtain DB2 12.1 Software
+*   Download the appropriate DB2 Version 12.1 edition (e.g., Standard, Advanced, Enterprise Server Edition) and FixPak level from IBM Passport Advantage or Fix Central.
+
+### 3.2. Installation Process
+*   It's common practice to install the new DB2 version in a separate directory from the old version. This allows for easier rollback if needed.
+*   **Example Installation Path:**
+    *   DB2 11.5 might be in: `/opt/ibm/db2/V11.5`
+    *   Install DB2 12.1 to: `/opt/ibm/db2/V12.1`
+*   **Run Installer:**
+    *   Extract the installation files.
+    *   Use `db2_install` (for non-interactive) or `db2setup` (for GUI).
+    ```bash
+    # Example using db2_install (as root)
+    cd /path_to_v12.1_extracted_media/server
+    ./db2_install -b /opt/ibm/db2/V12.1 -p SERVER -L EN -n
+    ```
+    Consult the `db2_install` documentation for specific product codes (`-p`).
+
+### 3.3. Verification of New Installation
+*   **`db2ls`:** (as root) List all DB2 installations on the server. Verify V12.1 is listed.
+    ```bash
+    /opt/ibm/db2/V12.1/install/db2ls -q -b /opt/ibm/db2/V12.1
+    ```
+*   **`db2level`:** (from new path) Check the version of the newly installed software.
+    ```bash
+    /opt/ibm/db2/V12.1/bin/db2level
+    ```
+
+---
+
+## 4. Phase 3: Upgrading DB2 Instances
+
+This phase upgrades your existing DB2 11.5 instance(s) to use the new DB2 12.1 software.
+
+### 4.1. Stop the DB2 11.5 Instance
+*   Ensure all applications are disconnected.
+*   Stop the instance cleanly:
+    ```bash
+    su - <your_11.5_instance_owner>
+    db2 force application all
+    db2 terminate
+    db2stop force # 'force' if necessary, prefer clean stop
+    # db2admin stop # If DAS is used and needs upgrade
+    ```
+
+### 4.2. Upgrade the Instance using `db2iupgrade`
+*   This command must be run as **root** from the DB2 Version 12.1 installation path.
+    ```bash
+    # As root
+    /opt/ibm/db2/V12.1/instance/db2iupgrade [options] <instance_name_11.5>
+    ```
+    *   Example: `/opt/ibm/db2/V12.1/instance/db2iupgrade db2inst1`
+    *   If you use a fenced user, you might need the `-u <fenced_user>` option.
+*   The `db2iupgrade` command updates the instance configuration to point to the new DB2 software version.
+
+### 4.3. Verify Instance Upgrade
+*   **Start the Upgraded Instance:**
+    ```bash
+    su - <instance_owner> # Instance owner should be the same
+    db2start
+    ```
+*   **Check `db2level`:**
+    ```bash
+    db2level
+    ```
+    This should now show DB2 Version 12.1.
+*   Check DBM CFG: `db2 GET DBM CFG`. Some parameters might have new defaults or ranges.
+
+---
+
+## 5. Phase 4: Upgrading Databases
+
+Once the instance is upgraded and running on DB2 12.1, you need to upgrade each database.
+
+### 5.1. Connect to Each Database
+*   Databases from the 11.5 instance will be cataloged but are in an "upgrade pending" state.
+    ```bash
+    su - <instance_owner>
+    db2 connect to <database_name>
+    ```
+    You might receive SQL1499W (SQLCODE for upgrade pending) on connection, which is expected.
+
+### 5.2. Run `UPGRADE DATABASE` Command
+*   This command performs the actual metadata and structural changes for the database.
+    ```bash
+    db2 UPGRADE DATABASE <database_name> [USER <user> USING <password>]
+    ```
+    *   The user specified needs SYSADM, DBADM, or equivalent authority.
+*   This step can take a significant amount of time depending on database size and complexity.
+
+### 5.3. Monitor Upgrade Progress
+*   Check the `db2diag.log` for progress and any errors.
+*   You can list utilities: `db2 list utilities show detail`.
+
+### 5.4. Resolve Issues During Database Upgrade
+*   If the `UPGRADE DATABASE` command fails, check `db2diag.log` for detailed error messages.
+*   Common issues could be related to tablespace states, invalid objects that `db2ckupgrade` didn't catch, or resource limitations.
+*   Address the issues and attempt the `UPGRADE DATABASE` command again.
+
+---
+
+## 6. Phase 5: Post-Upgrade Tasks
+
+After successfully upgrading the instance(s) and database(s).
+
+### 6.1. Run `db2updv121` (if applicable)
+*   The `db2updv121` command (located in `/opt/ibm/db2/V12.1/bin/`) updates database objects to the current FixPak level of V12.1. It's good practice to run this after a version upgrade and after applying new FixPaks.
+    ```bash
+    su - <instance_owner>
+    db2updv121 -d <database_name>
+    ```
+
+### 6.2. Rebind Packages
+*   Rebind all packages to take advantage of new optimizer features and ensure compatibility.
+    ```bash
+    su - <instance_owner>
+    db2rbind <database_name> -l /tmp/db2rbind_<database_name>.log all
+    ```
+*   Check the log file for any errors.
+
+### 6.3. Update Database Configuration (Optional)
+*   Review the database configuration (`db2 GET DB CFG FOR <database_name>`). New parameters or functionalities might be available in DB2 12.1.
+*   Adjust configurations based on performance testing and new features you wish to utilize.
+
+### 6.4. Full Post-Upgrade Backup
+*   Perform a full backup of each upgraded database using the new DB2 12.1 environment.
+    *   Use the `backup_db2.sh` script (ensure it's now using the V12.1 paths/environment if necessary, though the script itself is instance-dependent).
+
+### 6.5. Verify Application Connectivity and Functionality
+*   Thoroughly test all applications that connect to the upgraded databases.
+*   Check for any performance regressions or unexpected behavior.
+
+### 6.6. Clean Up Old DB2 11.5 Installation (Optional)
+*   Once you are confident that the DB2 12.1 environment is stable and you no longer need to roll back, you can plan to uninstall the old DB2 11.5 software.
+    ```bash
+    # As root, from the 11.5 installation path
+    /opt/ibm/db2/V11.5/install/db2_deinstall -a
+    ```
+    **Caution:** Ensure you have no intention of rolling back before doing this.
+
+---
+
+## 7. Rollback Strategy Considerations
+
+A rollback typically means reverting to the state before the upgrade attempt.
+*   **Instance Rollback:** If `db2iupgrade` fails, you might be able to run `db2iurevert` (consult IBM docs). If not, you would typically uninstall the failed V12.1 instance attempt and restore the V11.5 instance configuration if it was altered, or rely on OS-level backups.
+*   **Database Rollback:** The primary method is to restore from the full backups taken during the pre-upgrade phase (Phase 1).
+    1.  Uninstall/remove the V12.1 instance or ensure it's stopped.
+    2.  Reinstall or ensure the V11.5 instance is functional.
+    3.  Restore the V11.5 databases using the V11.5 instance from the pre-upgrade backups.
+*   **Thorough Backups are Key:** A successful rollback heavily depends on the quality and completeness of your pre-upgrade backups.
+
+---
+
+This guide provides a structured approach to upgrading DB2. Always consult the official IBM documentation and tailor the process to your specific environment. Good luck!

--- a/db2_update/DB2_Upgrade_Methods_Comparison.md
+++ b/db2_update/DB2_Upgrade_Methods_Comparison.md
@@ -1,0 +1,75 @@
+# Comparison of DB2 Upgrade Methods: 11.5 to 12.1
+
+**Version:** 1.0
+**Date:** 2024-06-18
+
+## Introduction
+
+When upgrading IBM DB2 from a previous version (e.g., 11.5) to a new major version (e.g., 12.1), administrators have a few general approaches. This document compares two common methods:
+
+1.  **Method A: In-Place Upgrade:** This involves upgrading the existing DB2 instance software and then upgrading the databases directly using IBM-provided utilities like `db2iupgrade` and `UPGRADE DATABASE`.
+2.  **Method B: Recreate Instance & Restore Databases:** This involves backing up databases from the old instance, dropping the old instance, creating a new instance with the new DB2 version's software, and then restoring the databases into the new instance.
+
+Choosing the right method depends on factors like acceptable downtime, risk tolerance, desired instance configuration state post-upgrade, and available resources.
+
+---
+
+## Method A: In-Place Upgrade
+
+This method directly upgrades the existing instance and its databases. The detailed steps for this method are covered in the [Comprehensive Guide: Upgrading IBM DB2 from Version 11.5 to Version 12.1](./DB2_Upgrade_11.5_to_12.1.md). A helper script, `scripts/in_place_upgrade_helper.sh`, is also available to guide through these steps.
+
+### Pros:
+*   **Configuration Retention:** Generally preserves most instance and database configuration settings, including DBM CFG, DB CFG, `db2set` registry variables, and cataloged node/DCS database entries. This can reduce post-upgrade reconfiguration effort.
+*   **Potentially Faster:** If all prerequisites are met and `db2ckupgrade` reports no issues, the actual upgrade process (`db2iupgrade` and `UPGRADE DATABASE`) can be faster than a full backup and restore cycle, especially for very large databases.
+*   **IBM Recommended Path:** This is often considered the standard and most direct upgrade path documented by IBM for version-to-version upgrades.
+*   **Less Disk Space (Potentially):** May require less temporary disk space compared to needing space for full backups alongside the live database during the process (though `UPGRADE DATABASE` can still consume significant transaction log space).
+
+### Cons:
+*   **"Messier" Environment:** Carries over the entire history and nuances of the old instance. If the old instance had accumulated problematic settings or minor inconsistencies, these might persist.
+*   **Rollback Complexity:** If the `db2iupgrade` or `UPGRADE DATABASE` commands fail midway, rollback can be more complex. While restoring from a pre-upgrade backup is the ultimate fallback, undoing a partially completed instance or database upgrade step itself can be challenging.
+*   **`db2ckupgrade` is Critical:** The success heavily relies on a clean run of `db2ckupgrade`. Any unresolved issues flagged by this tool can lead to upgrade failures.
+*   **Less Flexibility with OS/Storage Changes:** If the upgrade is part of a larger migration (e.g., new server, different storage layout), this method is less adaptable than Method B.
+
+---
+
+## Method B: Recreate Instance & Restore Databases
+
+This method involves building a new, clean instance with the target DB2 version and then restoring the user databases into it. The script `scripts/recreate_restore_upgrade.sh` is an example implementation of this approach.
+
+### Pros:
+*   **Clean Slate Instance:** Starts with a fresh DB2 instance using default configurations for the new version (unless explicitly scripted). This can eliminate old, potentially problematic or undocumented instance-level settings.
+*   **Simpler Rollback (Conceptually):** If the new instance or restore process fails, rolling back often means simply reverting to the old (still intact, if not dropped yet) instance and its databases, or restoring the pre-upgrade backups to the old version instance. The old instance is not directly modified until explicitly dropped.
+*   **OS/Storage Flexibility:** This method is more amenable if the upgrade coincides with a move to new hardware, OS upgrade, or storage reconfiguration, as the new instance is built independently.
+*   **Verification of Backups:** The process inherently validates the restorability of your database backups.
+
+### Cons:
+*   **Configuration Migration:** All necessary DBM CFG parameters, `db2set` variables, and other instance-level configurations from the old instance must be manually identified, validated for the new version, and reapplied to the new instance. This can be error-prone if not carefully managed. The user-provided script for this method handles some, but a full audit is needed.
+*   **Potentially Longer Downtime:** The complete cycle of backup, instance creation, and database restore can result in a longer overall downtime compared to a smooth in-place upgrade, especially for numerous or very large databases.
+*   **Database Cataloging:** After restoring, databases need to be cataloged if they were accessed as remote databases by clients. Node and DCS directory information might need manual recreation.
+*   **Not a True "Upgrade" of System Catalogs:** While restoring a database into a newer version makes it usable, the internal database catalog structures might not be as fully transformed as they would be with the `UPGRADE DATABASE` command. `db2updv<version>` (like `db2updv121`) helps, but `UPGRADE DATABASE` is specifically designed for version-to-version catalog evolution. This might have subtle implications for new features or optimizer behavior.
+
+---
+
+## Summary Comparison
+
+| Feature                 | Method A: In-Place Upgrade                 | Method B: Recreate & Restore             |
+|-------------------------|--------------------------------------------|------------------------------------------|
+| **Primary Commands**    | `db2iupgrade`, `UPGRADE DATABASE`          | `db2idrop`, `db2icrt`, `RESTORE DATABASE`|
+| **Instance State**      | Existing instance evolved                  | New, clean instance created              |
+| **Config. Retention**   | High (automatic)                           | Low (manual reapplication needed)        |
+| **Potential Downtime**  | Potentially shorter                        | Potentially longer                       |
+| **Rollback Simplicity** | Can be complex if mid-step failure       | Generally simpler (revert to old env)    |
+| **Disk Space (Op)**     | Moderate                                   | Higher (needs space for backups)         |
+| **"Cleanliness"**       | Carries over old instance history          | Fresh start                               |
+| **IBM Standard Path**   | Yes                                        | Alternative/Migration strategy           |
+| **Prep. Criticality**   | `db2ckupgrade` is vital                    | Backup integrity is vital                |
+| **Flexibility (OS/HW)** | Lower                                      | Higher                                   |
+
+---
+
+## Conclusion
+
+*   **Method A (In-Place Upgrade)** is often preferred for straightforward version upgrades on existing hardware where minimizing downtime (if all goes well) and retaining configurations are key priorities. It requires meticulous pre-upgrade checks.
+*   **Method B (Recreate Instance & Restore)** is a strong candidate when a "clean slate" is desired for the instance, when migrating to new hardware/OS, or if there are concerns about the stability/history of the old instance configuration. It demands careful planning for re-applying necessary configurations.
+
+Both methods require thorough testing in a non-production environment before attempting on production systems. Always consult the latest IBM DB2 Knowledge Center documentation.

--- a/db2_update/README.md
+++ b/db2_update/README.md
@@ -17,6 +17,10 @@ This directory contains a collection of scripts and instructions to assist with 
 5.  [FixPak Installation Guide (`scripts/install_fixpak.sh`)](#fixpak-installation-guide-scriptsinstall_fixpaksh)
 6.  [JDK Update Script (`scripts/update_jdk.sh`)](#jdk-update-script-scriptsupdate_jdksh)
 7.  [WebSphere JDBC Update](#websphere-jdbc-update)
+8.  [DB2 Version Upgrade (11.5 to 12.1)](#db2-version-upgrade-115-to-121)
+    *   [Upgrade Methods Comparison](#db2-version-upgrade-methods-comparison)
+    *   [Method A: In-Place Upgrade Guide & Helper Script](#method-a-in-place-upgrade-guide--helper-script)
+    *   [Method B: Recreate Instance & Restore Upgrade Script](#method-b-recreate-instance--restore-upgrade-script)
 
 ## Scripts Overview
 
@@ -148,6 +152,34 @@ Open `scripts/update_jdk.sh` and modify:
     su - <INSTANCE_NAME> -c "db2stop"
     su - <INSTANCE_NAME> -c "db2start"
     ```
+
+## DB2 Version Upgrade (11.5 to 12.1)
+
+Upgrading a DB2 instance from a major version like 11.5 to 12.1 is a significant operation that requires careful planning. There are two primary methods to achieve this, each with its own set of procedures, benefits, and drawbacks.
+
+### DB2 Version Upgrade Methods Comparison
+Before choosing an upgrade path, it's crucial to understand the differences between the available methods. We provide a detailed comparison document that outlines the pros and cons of each approach:
+*   **Read the Comparison Guide:** [DB2 Upgrade Methods Comparison](./DB2_Upgrade_Methods_Comparison.md)
+
+### Method A: In-Place Upgrade Guide & Helper Script
+For administrators looking to perform a major version upgrade of their DB2 environment from version 11.5 to 12.1, a detailed step-by-step guide is available. This guide covers critical phases including pre-upgrade preparations, software installation, instance upgrade, database upgrade, and post-upgrade tasks.
+
+*   **Read the full guide here:** [Comprehensive Guide: Upgrading IBM DB2 from Version 11.5 to 12.1](./DB2_Upgrade_11.5_to_12.1.md)
+
+**Note:** Major version upgrades are complex and should be thoroughly tested in a non-production environment first. Always refer to the official IBM DB2 Knowledge Center for the most current and detailed instructions specific to your environment.
+
+To assist with the step-by-step execution of the in-place upgrade, a helper script is provided. This script is not fully automated but guides you through the necessary commands and checks.
+*   **Helper Script:** `scripts/in_place_upgrade_helper.sh`
+*   **Usage:** Review and configure the script variables, then execute it, following the prompts and performing manual verifications as required. It's designed to be run alongside the detailed guide.
+
+### Method B: Recreate Instance & Restore Upgrade Script
+This method involves creating a fresh DB2 instance with the new version software and then restoring your databases from backups taken from the old instance. This approach can be preferable for a "clean slate" or when migrating hardware/OS.
+
+A script is provided to automate many steps of this process:
+*   **Script:** `scripts/recreate_restore_upgrade.sh`
+*   **Functionality:** This script handles backing up databases from the old instance, dropping the old instance, creating the new instance, restoring databases, and applying basic post-restore configurations.
+*   **Caution:** This script is destructive as it involves dropping the existing instance. Ensure you have full, verified backups and understand the script's operations by reviewing its content and the [Upgrade Methods Comparison](./DB2_Upgrade_Methods_Comparison.md) document. TEST THOROUGHLY in a non-production environment.
+*   **Configuration:** You MUST configure variables at the beginning of the script to match your environment (paths, instance names, etc.).
 
 ## WebSphere JDBC Update
 

--- a/db2_update/scripts/in_place_upgrade_helper.sh
+++ b/db2_update/scripts/in_place_upgrade_helper.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Helper Script for DB2 In-Place Upgrade (e.g., 11.5 to 12.1)
+# This script provides guidance and commands for an in-place DB2 upgrade.
+# It is NOT fully automated. You must run steps, verify, and make decisions.
+# Always consult official IBM documentation and test thoroughly in non-prod.
+
+# --- Configuration Variables ---
+# TODO: SET THESE VARIABLES BEFORE RUNNING ANY PART OF THIS SCRIPT
+OLD_DB2_PATH="/opt/ibm/db2/V11.5"                 # Path to your current (old) DB2 version
+NEW_DB2_PATH="/opt/ibm/db2/V12.1"                 # Path to your NEWLY INSTALLED DB2 version software
+INSTANCE_NAME="db2inst1"                          # DB2 instance name to upgrade
+DATABASE_NAMES=("SAMPLEDB" "MYDB2")               # Array of database names to upgrade (e.g., ("DB1" "DB2"))
+ADMIN_USER=""                                     # Admin user for db2ckupgrade, if needed (leave blank if not)
+ADMIN_PASS=""                                     # Admin password for db2ckupgrade (will prompt if blank and user is set)
+
+# Path to db2ckupgrade from the NEW DB2 version's installation media (before full install, or from an installed V12.1)
+# Example: /mnt/db2_v12_media/server/db2ckupgrade or /opt/ibm/db2/V12.1/bin/db2ckupgrade (if V12.1 already installed)
+# TODO: Ensure this path is correct.
+DB2CKUPGRADE_PATH="${NEW_DB2_PATH}/bin/db2ckupgrade" # Adjust if V12.1 is not yet installed and using media path
+
+LOG_DIR="/tmp/db2_upgrade_logs_$(date +%Y%m%d_%H%M%S)"
+mkdir -p "$LOG_DIR"
+MASTER_LOG="${LOG_DIR}/upgrade_master.log"
+
+# --- Helper Functions ---
+log_master() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$MASTER_LOG"
+}
+
+run_as_instance() {
+    local cmd="$1"
+    log_master "Attempting to run as instance user '$INSTANCE_NAME': $cmd"
+    su - "$INSTANCE_NAME" -c "$cmd" >> "$MASTER_LOG" 2>&1
+    # Capture and check return code more reliably if needed
+}
+
+run_as_root() {
+    local cmd="$1"
+    log_master "Attempting to run as root: $cmd"
+    eval "$cmd" >> "$MASTER_LOG" 2>&1
+    # Capture and check return code
+}
+
+pause_and_confirm() {
+    log_master "PAUSE: $1"
+    log_master "Review the output in $MASTER_LOG and specific log files in $LOG_DIR."
+    read -p "  Press Enter to continue, or Ctrl+C to abort..."
+}
+
+# --- Main Script ---
+log_master "=== DB2 In-Place Upgrade Helper Started ==="
+log_master "Instance: $INSTANCE_NAME"
+log_master "Old DB2 Path: $OLD_DB2_PATH"
+log_master "New DB2 Path: $NEW_DB2_PATH"
+log_master "Log Directory: $LOG_DIR"
+log_master "--- IMPORTANT: This script is a HELPER, not a fully automated solution. ---"
+log_master "--- You MUST verify each step and consult IBM documentation. ---"
+
+# Check if running as root for steps that require it
+if [ "$(id -u)" -ne 0 ]; then
+    log_master "WARNING: Some steps require root privileges. This script should ideally be run as root, or parts requiring root executed manually."
+    # For now, we'll continue, but specific commands might fail.
+fi
+
+pause_and_confirm "Initial setup verified. Ready to begin pre-upgrade tasks."
+
+# --- Phase 1: Pre-Upgrade Tasks ---
+log_master "--- Phase 1: Pre-Upgrade Tasks ---"
+
+log_master "Step 1.1: Ensure System Requirements for new DB2 version are met (OS, memory, disk)."
+log_master "  Action: Manual check. Refer to IBM documentation for DB2 $NEW_DB2_PATH."
+pause_and_confirm "System requirements checked?"
+
+log_master "Step 1.2: Perform FULL DATABASE BACKUPS for all databases."
+log_master "  Refer to 'backup_db2.sh' or your standard backup procedures."
+log_master "  Example for database ${DATABASE_NAMES[0]}:"
+log_master "  su - $INSTANCE_NAME -c "db2 backup database ${DATABASE_NAMES[0]} to /your_backup_location online""
+# Add loop if you want to provide example for all
+pause_and_confirm "Full backups completed and verified?"
+
+log_master "Step 1.3: Run db2ckupgrade for each database."
+log_master "  Using db2ckupgrade from: $DB2CKUPGRADE_PATH"
+if [ ! -f "$DB2CKUPGRADE_PATH" ]; then
+    log_master "  ERROR: db2ckupgrade utility not found at $DB2CKUPGRADE_PATH. Please correct the DB2CKUPGRADE_PATH variable."
+    exit 1
+fi
+for db_name in "${DATABASE_NAMES[@]}"; do
+    log_master "  Running db2ckupgrade for database: $db_name"
+    CKUPGRADE_LOG="${LOG_DIR}/db2ckupgrade_${db_name}.log"
+    cmd_opts=""
+    if [ -n "$ADMIN_USER" ]; then
+        cmd_opts="-u $ADMIN_USER"
+        if [ -n "$ADMIN_PASS" ]; then
+            cmd_opts="$cmd_opts -p $ADMIN_PASS"
+        else
+            # Prompt for password if user is set but pass is not
+            read -s -p "Enter password for $ADMIN_USER for $db_name db2ckupgrade: " temp_pass
+            echo
+            cmd_opts="$cmd_opts -p $temp_pass"
+            unset temp_pass
+        fi
+    fi
+    # db2ckupgrade must be run as instance owner, or user with connect & sysadm/sysctrl
+    # Assuming instance owner context here by not using run_as_instance for this specific command path
+    log_master "  Command: $DB2CKUPGRADE_PATH $db_name -l $CKUPGRADE_LOG $cmd_opts"
+    # This command often needs to be run by a user who can connect to the DB, typically the instance owner
+    # If this script is run as root, 'su - instance' is needed for this specific tool
+    su - "$INSTANCE_NAME" -c "$DB2CKUPGRADE_PATH $db_name -l $CKUPGRADE_LOG $cmd_opts" >> "$MASTER_LOG" 2>&1
+    log_master "  db2ckupgrade for $db_name log: $CKUPGRADE_LOG"
+    log_master "  IMPORTANT: Review $CKUPGRADE_LOG carefully. Resolve ALL issues before proceeding."
+    pause_and_confirm "db2ckupgrade for $db_name reviewed and issues resolved?"
+done
+
+log_master "Step 1.4: Save all DB2 configurations."
+CONFIG_BACKUP_DIR="${LOG_DIR}/config_backup_11.5"
+mkdir -p "$CONFIG_BACKUP_DIR"
+log_master "  Saving DBM CFG..."
+run_as_instance "db2 GET DBM CFG > ${CONFIG_BACKUP_DIR}/dbm_cfg.txt"
+log_master "  Saving db2set variables..."
+run_as_instance "db2set -all > ${CONFIG_BACKUP_DIR}/db2set_all.txt"
+for db_name in "${DATABASE_NAMES[@]}"; do
+    log_master "  Saving DB CFG for $db_name..."
+    run_as_instance "db2 CONNECT TO $db_name; db2 GET DB CFG FOR $db_name SHOW DETAIL > ${CONFIG_BACKUP_DIR}/db_cfg_${db_name}.txt; db2 CONNECT RESET"
+    log_master "  Saving db2look for $db_name..."
+    run_as_instance "db2look -d $db_name -e -l -x -o ${CONFIG_BACKUP_DIR}/db2look_${db_name}.sql"
+done
+log_master "  Configuration saved to: $CONFIG_BACKUP_DIR"
+pause_and_confirm "All configurations saved?"
+
+# --- Phase 2: Installing DB2 New Version Software ---
+log_master "--- Phase 2: Installing DB2 New Version Software ---"
+log_master "Step 2.1: Install the new DB2 version software (e.g., V12.1) into a NEW path ($NEW_DB2_PATH)."
+log_master "  Action: Manual step. Use db2_install or db2setup from the new version's media."
+log_master "  Ensure this is done BEFORE proceeding with instance upgrade."
+log_master "  Verify new installation with ${NEW_DB2_PATH}/bin/db2level and db2ls."
+pause_and_confirm "New DB2 version software installed and verified at $NEW_DB2_PATH?"
+
+# --- Phase 3: Upgrading DB2 Instance ---
+log_master "--- Phase 3: Upgrading DB2 Instance ($INSTANCE_NAME) ---"
+log_master "Step 3.1: Stop the DB2 instance ($INSTANCE_NAME) running under old version."
+log_master "  Ensure all applications are disconnected."
+run_as_instance "db2 force application all"
+run_as_instance "db2 terminate"
+run_as_instance "db2stop force" # Or a clean 'db2stop' if possible
+# run_as_instance "db2admin stop" # If applicable
+pause_and_confirm "Instance $INSTANCE_NAME stopped?"
+
+log_master "Step 3.2: Upgrade the instance using db2iupgrade. THIS REQUIRES ROOT PRIVILEGES."
+log_master "  Command: ${NEW_DB2_PATH}/instance/db2iupgrade $INSTANCE_NAME"
+log_master "  Log file for db2iupgrade will typically be in /tmp/db2iupgrade.log.<instance>"
+log_master "  If you are not root, you must execute this command manually as root."
+if [ "$(id -u)" -eq 0 ]; then
+    run_as_root "${NEW_DB2_PATH}/instance/db2iupgrade $INSTANCE_NAME"
+else
+    log_master "  ACTION REQUIRED: Run the above db2iupgrade command as root."
+fi
+pause_and_confirm "db2iupgrade command executed? Review its log for success."
+
+log_master "Step 3.3: Verify instance upgrade by starting instance and checking db2level."
+log_master "  The instance $INSTANCE_NAME should now be associated with $NEW_DB2_PATH."
+run_as_instance "db2start"
+run_as_instance "db2level"
+log_master "  Review output of db2level. It should show the NEW DB2 version."
+pause_and_confirm "Instance $INSTANCE_NAME started and db2level shows new version?"
+
+# --- Phase 4: Upgrading Databases ---
+log_master "--- Phase 4: Upgrading Databases ---"
+for db_name in "${DATABASE_NAMES[@]}"; do
+    log_master "Step 4.1 for $db_name: Upgrade the database."
+    log_master "  Command: db2 UPGRADE DATABASE $db_name"
+    run_as_instance "db2 UPGRADE DATABASE $db_name" # Add USER ... USING ... if needed
+    log_master "  Monitor db2diag.log for progress and errors during database upgrade."
+    pause_and_confirm "UPGRADE DATABASE command for $db_name completed? Review logs."
+done
+
+# --- Phase 5: Post-Upgrade Tasks ---
+log_master "--- Phase 5: Post-Upgrade Tasks ---"
+log_master "Step 5.1: Run db2updv<version> (e.g., db2updv121) for each database."
+DB2UPDV_CMD="${NEW_DB2_PATH}/bin/db2updv121" # Adjust version number if different
+if [ ! -f "$DB2UPDV_CMD" ]; then
+    log_master "  WARNING: $DB2UPDV_CMD not found. Skipping this step. Ensure it's run if applicable."
+else
+    for db_name in "${DATABASE_NAMES[@]}"; do
+        log_master "  Running $DB2UPDV_CMD for $db_name..."
+        run_as_instance "$DB2UPDV_CMD -d $db_name"
+    done
+fi
+pause_and_confirm "db2updv<version> completed for all databases?"
+
+log_master "Step 5.2: Rebind all packages."
+for db_name in "${DATABASE_NAMES[@]}"; do
+    log_master "  Rebinding packages for $db_name..."
+    REBIND_LOG="${LOG_DIR}/rebind_${db_name}.log"
+    run_as_instance "db2rbind $db_name -l $REBIND_LOG all"
+    log_master "  Rebind log for $db_name: $REBIND_LOG. Check for errors."
+done
+pause_and_confirm "Rebind packages completed for all databases?"
+
+log_master "Step 5.3: Review and update database/DBM configurations if needed."
+log_master "  Compare with configurations saved in $CONFIG_BACKUP_DIR."
+log_master "  Action: Manual review and `db2 update ...` commands if necessary."
+pause_and_confirm "Configurations reviewed and updated?"
+
+log_master "Step 5.4: Perform FULL DATABASE BACKUPS for all upgraded databases."
+log_master "  Example for database ${DATABASE_NAMES[0]}:"
+log_master "  su - $INSTANCE_NAME -c "db2 backup database ${DATABASE_NAMES[0]} to /your_post_upgrade_backup_location online""
+pause_and_confirm "Post-upgrade backups completed?"
+
+log_master "Step 5.5: Thoroughly test all applications."
+log_master "  Action: Manual step."
+
+log_master "--- DB2 In-Place Upgrade Helper Finished ---"
+log_master "Review all logs in $LOG_DIR for details and any errors."
+log_master "Remember to consult official IBM documentation throughout this process."
+
+# Make the script executable after creation
+# chmod +x db2_update/scripts/in_place_upgrade_helper.sh

--- a/db2_update/scripts/recreate_restore_upgrade.sh
+++ b/db2_update/scripts/recreate_restore_upgrade.sh
@@ -1,0 +1,367 @@
+#!/bin/bash
+# Script for DB2 Upgrade (e.g., 11.5 to 12.1) via Instance Recreation and Database Restore
+# Original script concept provided by the user. Refactored for clarity and robustness.
+# This script automates:
+# 1. Backup of databases from the old instance.
+# 2. Dropping the old instance.
+# 3. Creating a new instance with the new DB2 version.
+# 4. Restoring databases into the new instance.
+# 5. Applying post-restore configurations.
+# WARNING: This script is destructive as it drops the DB2 instance.
+#          Ensure full, verified backups exist and you understand the process.
+#          TEST THOROUGHLY IN A NON-PRODUCTION ENVIRONMENT.
+
+set -euo pipefail # Exit on error, undefined variable, or pipe failure
+
+# --- Configuration Variables ---
+# TODO: VERIFY AND SET ALL THESE VARIABLES BEFORE EXECUTION
+OLD_VERSION_DB2_PATH="/opt/ibm/db2/V11.5"       # Path to your current (old) DB2 version binaries
+NEW_VERSION_DB2_PATH="/opt/ibm/db2/V12.1"       # Path to your NEWLY INSTALLED DB2 version binaries
+INSTANCE_NAME="db2inst1"                        # DB2 instance name (will be dropped and recreated)
+FENCED_USER="db2fnc1"                           # Fenced user for the new instance (as in user script: db2fenc1)
+INSTANCE_PORT=50000                             # Instance port for the new instance (as in user script)
+DB2_INSTALL_TYPE="-s ese"                       # Server type for db2icrt (e.g., -s ese, -s wse, -s client)
+                                                # User script had '-s ese -a SERVER_ENCRYPT'. -a is auth type.
+DB2_AUTH_TYPE="-a SERVER_ENCRYPT"               # Authentication type for new instance
+
+BACKUP_BASE_DIR="/db2backup/upgrade_backups"    # Base directory for backups
+# Backup dir will be BACKUP_BASE_DIR/YYYYMMDD_HHMMSS
+# LOG_BASE_DIR="/var/log/db2_upgrades"          # Base directory for log files (user script used /var/log)
+LOG_BASE_DIR="/tmp/db2_upgrades"                # Safer default for general use, change if /var/log is desired & perms allow
+# Log file will be LOG_BASE_DIR/upgrade_YYYYMMDD_HHMMSS.log
+
+# Data and log paths for the NEW instance (ensure these directories exist or can be created by instance owner)
+# User script created /db2data and /db2logs and chowned them to instance owner
+NEW_DB_DATA_PATH="/db2data"                     # Example: /db2/${INSTANCE_NAME}/data
+NEW_DB_LOG_PATH="/db2logs"                      # Example: /db2/${INSTANCE_NAME}/logs
+                                                # This script will attempt to create and chown these.
+
+# --- Global Variables ---
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_DIR="${BACKUP_BASE_DIR}/${TIMESTAMP}"
+LOG_FILE="${LOG_BASE_DIR}/db2_upgrade_${INSTANCE_NAME}_${TIMESTAMP}.log"
+ROLLBACK_SCRIPT_PATH="/tmp/db2_rollback_${INSTANCE_NAME}_${TIMESTAMP}.sh"
+DB_LIST=() # Array to store database names
+
+# --- Helper Functions ---
+# Ensure log directory exists
+mkdir -p "$LOG_BASE_DIR" || { echo "FATAL: Could not create log directory $LOG_BASE_DIR. Exiting."; exit 1; }
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Function to execute commands as the instance owner
+run_as_instance() {
+    local cmd_to_run="$1"
+    log "Instance Command: $cmd_to_run"
+    su - "$INSTANCE_NAME" -c "$cmd_to_run" >> "$LOG_FILE" 2>&1
+    if [ $? -ne 0 ]; then
+        log "ERROR: Instance command failed: '$cmd_to_run'. Check $LOG_FILE for details."
+        # Decide if this should be a fatal error for all commands
+        return 1
+    fi
+    return 0
+}
+
+# Function to execute commands as root (current user)
+run_as_root() {
+    local cmd_to_run="$1"
+    log "Root Command: $cmd_to_run"
+    eval "$cmd_to_run" >> "$LOG_FILE" 2>&1
+    if [ $? -ne 0 ]; then
+        log "ERROR: Root command failed: '$cmd_to_run'. Check $LOG_FILE for details."
+        return 1 # Propagate error
+    fi
+    return 0
+}
+
+# Function to create a basic rollback script
+create_rollback_script() {
+    log "Creating rollback script at $ROLLBACK_SCRIPT_PATH..."
+    # The rollback script would try to recreate the OLD version instance and restore.
+    # This is a simplified version. A true rollback might involve more.
+    cat > "$ROLLBACK_SCRIPT_PATH" <<- EOR
+#!/bin/bash
+set -e
+echo "[\\$(date '+%Y-%m-%d %H:%M:%S')] === Starting Rollback Process ===" | tee -a ${LOG_FILE}_rollback.log
+echo "This script attempts to restore instance $INSTANCE_NAME using $OLD_VERSION_DB2_PATH and backups from $BACKUP_DIR" | tee -a ${LOG_FILE}_rollback.log
+
+echo "Step 1: Recreate instance $INSTANCE_NAME with $OLD_VERSION_DB2_PATH" | tee -a ${LOG_FILE}_rollback.log
+# Assuming similar instance creation parameters for the old version. Adjust if needed.
+# This is a critical assumption. The original fenced user and port for 11.5 would be needed.
+# For simplicity, using the same FENCED_USER and INSTANCE_PORT as defined for the new instance.
+${OLD_VERSION_DB2_PATH}/instance/db2icrt $DB2_INSTALL_TYPE $DB2_AUTH_TYPE -p $INSTANCE_PORT -u $FENCED_USER $INSTANCE_NAME >> ${LOG_FILE}_rollback.log 2>&1
+if [ \$? -ne 0 ]; then echo "ERROR: Failed to recreate old instance $INSTANCE_NAME. Manual intervention required." | tee -a ${LOG_FILE}_rollback.log; exit 1; fi
+
+echo "Step 2: Start instance $INSTANCE_NAME" | tee -a ${LOG_FILE}_rollback.log
+su - $INSTANCE_NAME -c "db2start" >> ${LOG_FILE}_rollback.log 2>&1
+if [ \$? -ne 0 ]; then echo "ERROR: Failed to start recreated instance $INSTANCE_NAME. Manual intervention required." | tee -a ${LOG_FILE}_rollback.log; exit 1; fi
+
+echo "Step 3: Restore databases" | tee -a ${LOG_FILE}_rollback.log
+EOR
+
+    # Add restore commands for each database
+    for db_name_rb in "${DB_LIST[@]}"; do
+        echo "su - $INSTANCE_NAME -c "db2 restore database $db_name_rb from $BACKUP_DIR replace existing" >> ${LOG_FILE}_rollback.log 2>&1" >> "$ROLLBACK_SCRIPT_PATH"
+        echo "if [ \\$? -ne 0 ]; then echo 'ERROR: Failed to restore $db_name_rb.' | tee -a ${LOG_FILE}_rollback.log; fi" >> "$ROLLBACK_SCRIPT_PATH"
+    done
+
+    cat >> "$ROLLBACK_SCRIPT_PATH" <<- EOR
+echo "[\\$(date '+%Y-%m-%d %H:%M:%S')] === Rollback Script Finished ===" | tee -a ${LOG_FILE}_rollback.log
+EOR
+    chmod +x "$ROLLBACK_SCRIPT_PATH"
+    log "Rollback script created: $ROLLBACK_SCRIPT_PATH"
+    log "IMPORTANT: Review this rollback script. It makes assumptions about the old instance creation."
+}
+
+# --- Pre-flight Checks ---
+pre_flight_checks() {
+    log "--- Starting Pre-flight Checks ---"
+    if [ "$(id -u)" -ne 0 ]; then
+        log "FATAL ERROR: This script must be run as root."
+        exit 1
+    fi
+
+    log "Checking for old DB2 path: $OLD_VERSION_DB2_PATH"
+    [ -d "$OLD_VERSION_DB2_PATH" ] || { log "FATAL ERROR: Old DB2 path '$OLD_VERSION_DB2_PATH' not found."; exit 1; }
+    log "Checking for new DB2 path: $NEW_VERSION_DB2_PATH"
+    [ -d "$NEW_VERSION_DB2_PATH" ] || { log "FATAL ERROR: New DB2 path '$NEW_VERSION_DB2_PATH' not found. Install new DB2 software first."; exit 1; }
+
+    log "Checking disk space for backups in $(dirname "$BACKUP_BASE_DIR") (estimate 50G free needed)..."
+    # Simplified check, adjust size as needed. User script had 50G.
+    df -BG $(dirname "$BACKUP_BASE_DIR") | awk 'NR==2 {if ($4 < 50) exit 1}' || { log "WARNING: Less than 50G free in backup directory parent. Monitor closely."; }
+
+    log "Checking disk space in /tmp (estimate 5G free needed)..."
+    df -BG /tmp | awk 'NR==2 {if ($4 < 5) exit 1}' || { log "WARNING: Less than 5G free in /tmp. Monitor closely."; }
+
+    log "--- Pre-flight Checks Completed ---"
+}
+
+# --- Main Upgrade Steps ---
+stop_and_prep_old_instance() {
+    log "--- Stopping and Preparing Old Instance ($INSTANCE_NAME) ---"
+    log "Forcing applications off and stopping instance $INSTANCE_NAME."
+    # run_as_instance "db2 force application all" # This will fail if instance not started, or if it is, might be too soon.
+    # Let's try to stop it first.
+    if ! su - "$INSTANCE_NAME" -c "db2stop force" >> "$LOG_FILE" 2>&1; then
+        log "WARN: db2stop force failed, instance might have been already stopped or encountered an issue."
+    fi
+    log "Attempting to clean up any remaining instance processes (pkill)."
+    pkill -9 -u "$INSTANCE_NAME" &>> "$LOG_FILE" || log "pkill found no processes for $INSTANCE_NAME or failed (non-critical)."
+    log "Old instance $INSTANCE_NAME stopped and processes cleaned."
+}
+
+backup_databases_from_old_instance() {
+    log "--- Backing Up Databases from Old Instance ---"
+    log "Ensuring instance $INSTANCE_NAME (old version) is started for backups..."
+    # This is tricky if we just stopped it. The original script implies it's up for backup.
+    # Let's assume it needs to be running with OLD_VERSION_DB2_PATH
+    # This requires the instance to be associated with OLD_VERSION_DB2_PATH
+    # If db2idrop was run before this, this step is impossible.
+    # The user script has db2stop force, then lists DBs, then backups. This implies db2 list db directory works on a stopped instance or it implicitly starts.
+    # For safety, let's ensure it's started with the old path.
+    # This is a conceptual challenge if the instance is already stopped. A proper backup should be taken when it's running.
+    # The user's script structure: stop -> list dbs -> backup.
+    # `db2 list db directory` works without the instance being started.
+
+    log "Listing databases for instance $INSTANCE_NAME..."
+    mapfile -t DB_LIST < <(su - "$INSTANCE_NAME" -c ". ${OLD_VERSION_DB2_PATH}/db2profile; db2 list db directory" | awk '/Database alias|Aliasname der Datenbank/ {print $(NF)}')
+    # Original user script was: awk '/Database alias|Aliasname der Datenbank/ {print $5}' -- this might be locale specific. NF is more robust.
+
+    if [ ${#DB_LIST[@]} -eq 0 ]; then
+        log "WARNING: No databases found for instance $INSTANCE_NAME. Proceeding, but no databases will be backed up or restored."
+    else
+        log "Databases to be backed up: ${DB_LIST[*]}"
+    fi
+
+    log "Creating backup directory: $BACKUP_DIR"
+    mkdir -p "$BACKUP_DIR" || { log "FATAL ERROR: Could not create backup directory $BACKUP_DIR."; exit 1; }
+    chown "$INSTANCE_NAME:$FENCED_USER" "$BACKUP_DIR" # Assuming FENCED_USER group is same as instance primary group or similar (e.g. db2iadm1)
+                                                    # User script had instance:db2iadm1. Using FENCED_USER as a guess for group.
+                                                    # This might need adjustment based on actual group names.
+
+    create_rollback_script # Create rollback script now that we have DB_LIST
+
+    log "Starting instance $INSTANCE_NAME with old software for backup (if not already running)..."
+    # This is essential. Backups must be from a running instance.
+    # The profile must be sourced from the OLD version.
+    if ! su - "$INSTANCE_NAME" -c ". ${OLD_VERSION_DB2_PATH}/db2profile; db2start" >> "$LOG_FILE" 2>&1; then
+        log "FATAL ERROR: Failed to start instance $INSTANCE_NAME using $OLD_VERSION_DB2_PATH for backups. Cannot proceed."
+        exit 1
+    fi
+
+    for db_name in "${DB_LIST[@]}"; do
+        log "Backing up database: $db_name to $BACKUP_DIR"
+        if ! run_as_instance ". ${OLD_VERSION_DB2_PATH}/db2profile; db2 backup database $db_name to $BACKUP_DIR include logs"; then
+            log "FATAL ERROR: Backup failed for database $db_name. Cannot proceed."
+            exit 1 # Critical step
+        fi
+        log "Backup for $db_name completed."
+    done
+
+    log "All database backups completed. Stopping instance $INSTANCE_NAME before dropping."
+    if ! run_as_instance ". ${OLD_VERSION_DB2_PATH}/db2profile; db2stop force"; then
+         log "WARN: Failed to stop instance $INSTANCE_NAME after backups. Proceeding with caution."
+    fi
+    log "--- Database Backups Finished ---"
+}
+
+manage_instance() {
+    log "--- Managing DB2 Instance ---"
+    log "Dropping old instance $INSTANCE_NAME (associated with $OLD_VERSION_DB2_PATH)."
+    # This command must be run as root.
+    if ! run_as_root "${OLD_VERSION_DB2_PATH}/instance/db2idrop -f $INSTANCE_NAME"; then
+        # db2idrop can sometimes fail if resources are held. A retry or manual check might be needed.
+        log "WARNING: db2idrop for $INSTANCE_NAME failed. This could be an issue if the instance still exists. Trying to continue..."
+        # This is not ideal. If db2idrop fails, db2icrt might also fail.
+    else
+        log "Old instance $INSTANCE_NAME dropped successfully."
+    fi
+
+    log "Creating new instance $INSTANCE_NAME with $NEW_VERSION_DB2_PATH."
+    # This command must be run as root.
+    # User script: "$NEW_VERSION"/instance/db2icrt -s ese -a SERVER_ENCRYPT -p 50000 -u "$FENCEUSER" "$INSTANCE"
+    local db2icrt_cmd="${NEW_VERSION_DB2_PATH}/instance/db2icrt ${DB2_INSTALL_TYPE} ${DB2_AUTH_TYPE} -p ${INSTANCE_PORT} -u ${FENCED_USER} ${INSTANCE_NAME}"
+    if ! run_as_root "$db2icrt_cmd"; then
+        log "FATAL ERROR: Failed to create new instance $INSTANCE_NAME using db2icrt. Check $LOG_FILE."
+        exit 1
+    fi
+    log "New instance $INSTANCE_NAME created successfully."
+    log "--- Instance Management Finished ---"
+}
+
+prepare_new_instance_env() {
+    log "--- Preparing New Instance Environment ---"
+    log "Creating and setting permissions for data and log paths..."
+    mkdir -p "$NEW_DB_DATA_PATH" "$NEW_DB_LOG_PATH"
+    if [ $? -ne 0 ]; then
+        log "WARNING: Could not create $NEW_DB_DATA_PATH or $NEW_DB_LOG_PATH. Please ensure they exist and have correct permissions."
+    else
+        # Attempt to chown. This might fail if script runner doesn't have perms on parent of NEW_DB_DATA_PATH
+        chown -R "$INSTANCE_NAME:$FENCED_USER" "$NEW_DB_DATA_PATH" "$NEW_DB_LOG_PATH" # Again, FENCED_USER as group is a guess.
+        chmod 750 "$NEW_DB_DATA_PATH" "$NEW_DB_LOG_PATH" # User script had 750
+        log "Data/log paths $NEW_DB_DATA_PATH, $NEW_DB_LOG_PATH configured."
+    fi
+
+
+    log "Starting new instance $INSTANCE_NAME for restores..."
+    # Must source the new DB2 profile
+    if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2start"; then
+        log "FATAL ERROR: Failed to start new instance $INSTANCE_NAME using $NEW_VERSION_DB2_PATH. Cannot proceed with restores."
+        exit 1
+    fi
+    log "New instance $INSTANCE_NAME started."
+    log "--- New Instance Environment Prepared ---"
+}
+
+restore_and_configure_databases() {
+    log "--- Restoring and Configuring Databases in New Instance ---"
+    if [ ${#DB_LIST[@]} -eq 0 ]; then
+        log "No databases were in DB_LIST. Skipping restore and configuration."
+        return
+    fi
+
+    for db_name in "${DB_LIST[@]}"; do
+        log "Restoring database: $db_name from $BACKUP_DIR"
+        if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2 restore database $db_name from '$BACKUP_DIR' replace existing"; then
+            log "ERROR: Restore failed for database $db_name. Skipping further configuration for this DB."
+            continue # Move to next database
+        fi
+        log "Restore for $db_name completed."
+
+        log "Running catalog update (db2updv121) for $db_name" # Assuming V12.1, make variable if needed
+        local db2updv_cmd="${NEW_VERSION_DB2_PATH}/bin/db2updv121" # Adjust if target version is different
+        if [ ! -f "$db2updv_cmd" ]; then
+            log "WARNING: $db2updv_cmd not found. Skipping for $db_name."
+        elif ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; $db2updv_cmd -d $db_name"; then
+            log "WARNING: db2updv command failed for $db_name. Database might not be at latest FixPak level."
+        else
+            log "db2updv for $db_name completed."
+        fi
+
+        log "Updating NEWLOGPATH for $db_name to $NEW_DB_LOG_PATH (or a sub-path if DB2 creates it)"
+        # DB2 creates specific log paths like NODE0000/SQL00001/. So just setting NEWLOGPATH to the base might be enough,
+        # or one might need to specify the full path if known.
+        # The original script set it to a general /db2logs.
+        # Let's make this more specific per database if possible, or use the general one.
+        # For now, using the general path as per user script.
+        if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2 update db cfg for $db_name using NEWLOGPATH $NEW_DB_LOG_PATH"; then
+            log "WARNING: Failed to update NEWLOGPATH for $db_name."
+        else
+            log "NEWLOGPATH for $db_name updated."
+        fi
+    done
+    log "--- Database Restore and Configuration Finished ---"
+}
+
+apply_post_upgrade_settings() {
+    log "--- Applying Post-Upgrade Settings ---"
+    log "Setting DB2_USE_ALTERNATE_PAGE_CLEANING=ON for instance $INSTANCE_NAME"
+    if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2set DB2_USE_ALTERNATE_PAGE_CLEANING=ON"; then
+        log "WARNING: Failed to set DB2_USE_ALTERNATE_PAGE_CLEANING."
+    fi
+
+    log "Rebinding all packages for all databases..."
+    # The original script did `db2rbind all`. This command is not valid.
+    # It should be `db2rbind <dbname> -l <logfile> all`
+    local rebind_log_path="${LOG_DIR}/rebind_all_dbs.log" # Single log for all rbinds for simplicity
+    for db_name in "${DB_LIST[@]}"; do
+        log "Rebinding packages for database $db_name..."
+        if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2rbind $db_name -l ${LOG_DIR}/rebind_${db_name}.log all"; then
+            log "WARNING: db2rbind failed for $db_name. Check ${LOG_DIR}/rebind_${db_name}.log."
+        fi
+    done
+    log "Package rebinding attempt finished for all databases."
+
+    log "Restarting instance $INSTANCE_NAME to apply all changes."
+    if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2stop force"; then
+        log "WARNING: db2stop force failed during final restart."
+    fi
+    if ! run_as_instance ". ${NEW_VERSION_DB2_PATH}/db2profile; db2start"; then
+        log "ERROR: Failed to start instance $INSTANCE_NAME after final configurations. Manual check required."
+    else
+        log "Instance $INSTANCE_NAME restarted successfully."
+    fi
+    log "--- Post-Upgrade Settings Applied ---"
+}
+
+# --- Main Execution Flow ---
+main() {
+    # Initial log setup
+    echo "DB2 Upgrade Script (Recreate & Restore Method)" > "$LOG_FILE"
+    echo "Timestamp: $(date '+%Y-%m-%d %H:%M:%S')" >> "$LOG_FILE"
+    echo "--- CONFIGURATION ---" >> "$LOG_FILE"
+    echo "OLD_VERSION_DB2_PATH: $OLD_VERSION_DB2_PATH" >> "$LOG_FILE"
+    echo "NEW_VERSION_DB2_PATH: $NEW_VERSION_DB2_PATH" >> "$LOG_FILE"
+    echo "INSTANCE_NAME: $INSTANCE_NAME" >> "$LOG_FILE"
+    echo "FENCED_USER: $FENCED_USER" >> "$LOG_FILE"
+    echo "BACKUP_DIR: $BACKUP_DIR" >> "$LOG_FILE"
+    echo "LOG_FILE: $LOG_FILE" >> "$LOG_FILE"
+    echo "--- END CONFIGURATION ---" >> "$LOG_FILE"
+
+    log "=== DB2 UPGRADE PROCESS (RECREATE & RESTORE) INITIATED ==="
+    log "WARNING: This script is destructive and will drop instance $INSTANCE_NAME."
+    read -p "ARE YOU SURE YOU WANT TO CONTINUE? (yes/N): " confirmation
+    if [[ "$confirmation" != "yes" ]]; then
+        log "User aborted operation. Exiting."
+        exit 0
+    fi
+
+    pre_flight_checks
+    stop_and_prep_old_instance         # Stop instance (makes sure it's not running with old profile)
+    backup_databases_from_old_instance # Starts with old profile for backup, then stops
+    manage_instance                    # Drops old, creates new
+    prepare_new_instance_env           # Starts new instance with new profile
+    restore_and_configure_databases
+    apply_post_upgrade_settings
+
+    log "=== DB2 UPGRADE PROCESS (RECREATE & RESTORE) COMPLETED SUCCESSFULLY ==="
+    log "Please review the master log: $LOG_FILE"
+    log "And the rollback script (if needed, review carefully): $ROLLBACK_SCRIPT_PATH"
+}
+
+# Kick off the main function
+main
+
+# Make the script executable: chmod +x db2_update/scripts/recreate_restore_upgrade.sh


### PR DESCRIPTION
…riants.

This change introduces documentation comparing two primary methods for upgrading DB2 (e.g., from v11.5 to v12.1) and provides scripts to assist with each method.

1.  **DB2 Upgrade Methods Comparison Document:**
    *   `db2_update/DB2_Upgrade_Methods_Comparison.md`: A new document detailing the pros and cons of:
        *   Method A: In-Place Upgrade (`db2iupgrade`, `UPGRADE DATABASE`)
        *   Method B: Recreate Instance & Restore Databases (`db2idrop`, `db2icrt`, `RESTORE DATABASE`)
    *   Includes a summary table for quick comparison.

2.  **Scripts for Upgrade Methods:**
    *   `db2_update/scripts/in_place_upgrade_helper.sh` (Method A): A new helper script that guides you step-by-step through an in-place upgrade. It's not fully automated but provides commands, checks, and logging for each phase.
    *   `db2_update/scripts/recreate_restore_upgrade.sh` (Method B): Refactored and enhanced version of a script you provided. This script automates the process of backing up databases from an old instance, dropping the old instance, creating a new instance with the new DB2 version, restoring databases, and applying post-restore configurations.

3.  **Updated Documentation:**
    *   `db2_update/README.md`: Significantly updated to include sections for the upgrade methods comparison, and details/links for both new upgrade scripts. The Table of Contents and overall structure for upgrade information have been improved.

This provides you with a clearer understanding of your upgrade options and tools to support either chosen method.