### PR TITLE
Refactor: Make backup/restore optional in recreate_restore_upgrade.sh

### DIFF
--- a/db2_update/DB2_Upgrade_Methods_Comparison.md
+++ b/db2_update/DB2_Upgrade_Methods_Comparison.md
@@ -34,7 +34,7 @@ This method directly upgrades the existing instance and its databases. The detai
 
 ## Method B: Recreate Instance & Restore Databases
 
-This method involves building a new, clean instance with the target DB2 version and then restoring the user databases into it. The script `scripts/recreate_restore_upgrade.sh` is an example implementation of this approach.
+This method involves building a new, clean instance with the target DB2 version and then restoring the user databases into it. The script `scripts/recreate_restore_upgrade.sh` is an example implementation of this approach, offering options for either automated or manual execution of the backup and restore phases within its workflow.
 
 ### Pros:
 *   **Clean Slate Instance:** Starts with a fresh DB2 instance using default configurations for the new version (unless explicitly scripted). This can eliminate old, potentially problematic or undocumented instance-level settings.

--- a/db2_update/README.md
+++ b/db2_update/README.md
@@ -177,9 +177,18 @@ This method involves creating a fresh DB2 instance with the new version software
 
 A script is provided to automate many steps of this process:
 *   **Script:** `scripts/recreate_restore_upgrade.sh`
-*   **Functionality:** This script handles backing up databases from the old instance, dropping the old instance, creating the new instance, restoring databases, and applying basic post-restore configurations.
+*   **Functionality:** This script manages dropping the old DB2 instance, creating a new instance with the new DB2 version, and applying post-restore configurations. It can *optionally* handle the database backup (from the old instance) and restore (to the new instance) steps automatically. By default, automated backup/restore are disabled, requiring manual intervention for these critical data operations.
 *   **Caution:** This script is destructive as it involves dropping the existing instance. Ensure you have full, verified backups and understand the script's operations by reviewing its content and the [Upgrade Methods Comparison](./DB2_Upgrade_Methods_Comparison.md) document. TEST THOROUGHLY in a non-production environment.
-*   **Configuration:** You MUST configure variables at the beginning of the script to match your environment (paths, instance names, etc.).
+*   **Backup and Restore Flexibility:**
+    *   The script includes two boolean variables to control data handling:
+        *   `PERFORM_AUTOMATED_BACKUP` (default: `false`): If set to `true`, the script will attempt to back up databases from the old instance.
+        *   `PERFORM_AUTOMATED_RESTORE` (default: `false`): If set to `true`, the script will attempt to restore databases into the new instance.
+    *   **Default Manual Mode:** With defaults set to `false`, the script will prompt you to:
+        1.  Manually back up your databases from the old instance before the old instance is dropped. You can use the `backup_db2.sh` script or your own methods. Ensure backups are placed in the directory specified by the `BACKUP_DIR` variable in `recreate_restore_upgrade.sh`.
+        2.  Manually restore your databases into the newly created instance. You can use the `restore_db2.sh` script or your own methods, using backups from the `BACKUP_DIR`.
+    *   The script will continue with instance management (drop/create) and post-restore configurations (like `db2updv121`, `NEWLOGPATH` updates, `db2rbind`) regardless of these settings, assuming the databases are made available in the new instance.
+
+*   **Configuration:** You MUST configure variables at the beginning of the script to match your environment (paths, instance names, `PERFORM_AUTOMATED_BACKUP`, `PERFORM_AUTOMATED_RESTORE`, etc.).
 
 ## WebSphere JDBC Update
 


### PR DESCRIPTION
This commit updates the `recreate_restore_upgrade.sh` script to make the database backup and restore operations optional, controlled by new boolean variables `PERFORM_AUTOMATED_BACKUP` and `PERFORM_AUTOMATED_RESTORE` (defaulting to `false`).

Key changes:
-   **`db2_update/scripts/recreate_restore_upgrade.sh`:**
    *   Added `PERFORM_AUTOMATED_BACKUP` and `PERFORM_AUTOMATED_RESTORE`
        variables.
    *   If set to `false` (default), the script now instructs you
        to perform these operations manually and waits for confirmation
        before proceeding with instance management and post-restore
        configurations.
    *   If set to `true`, the script executes its internal backup/restore logic.
    *   Post-restore steps (e.g., `db2updv121`, `NEWLOGPATH` update) are
        still performed by the script, assuming databases are available
        in the new instance.

-   **`db2_update/README.md`:**
    *   Updated the "Method B: Recreate Instance & Restore Upgrade Script"
        section to explain the new optional functionality, the control
        variables, and the manual workflow if automation is disabled.

-   **`db2_update/DB2_Upgrade_Methods_Comparison.md`:**
    *   Minor update to the description of Method B to mention that the
        associated script (`recreate_restore_upgrade.sh`) offers
        flexibility in handling the backup and restore phases.

This change provides you more control over the upgrade process when using the recreate and restore method, allowing manual intervention for critical data handling steps if preferred.